### PR TITLE
Assume models are homogeneous

### DIFF
--- a/mmtf-api/pom.xml
+++ b/mmtf-api/pom.xml
@@ -20,11 +20,6 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.rcsb</groupId>
-			<artifactId>mmtf-common</artifactId>
-			<version>0.0.1-alpha4-SNAPSHOT</version>
-		</dependency>
-		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.11</version>

--- a/mmtf-api/src/main/java/org/rcsb/mmtf/api/DataApiInterface.java
+++ b/mmtf-api/src/main/java/org/rcsb/mmtf/api/DataApiInterface.java
@@ -1,12 +1,8 @@
 package org.rcsb.mmtf.api;
 
 import java.util.List;
-import java.util.Map;
 
 import org.rcsb.mmtf.dataholders.BioAssemblyData;
-import org.rcsb.mmtf.dataholders.Entity;
-import org.rcsb.mmtf.dataholders.MmtfBean;
-import org.rcsb.mmtf.dataholders.PDBGroup;
 
 /**
  * An interface describing the data API.
@@ -90,13 +86,68 @@ public interface DataApiInterface {
 	 */
 	int[] getResidueNums();
 
+
 	/**
-	 * Returns the group map, mapping the numbers from indices specified in {@link #getGroupIndices()} 
-	 * to {@link PDBGroup} objects, which specify the atom names, 
-	 * elements, bonds and charges for each group.
-	 * @return a map of group indices to {@link PDBGroup} objects
+	 * Returns the group name for the group specified in {@link #getGroupIndices()}.
+	 * to link groups to the 3 letter group name, e.g. HIS.
+	 * @param groupInd The index of the group specified in {@link #getGroupIndices()}.
+	 * @return a 3 letter string specifiying the group name.
 	 */
-	Map<Integer, PDBGroup> getGroupMap();
+	String getGroupName(int groupInd);
+	
+	/**
+	 * Returns the number of atoms in the group specified in {@link #getGroupIndices()}.
+	 * @param groupInd The index of the group specified in {@link #getGroupIndices()}.
+	 * @return The number of atoms in the group
+	 */	
+	int getNumAtomsInGroup(int groupInd);
+	
+
+	/** Returns the atom names (e.g. CB) for the group specified in {@link #getGroupIndices()}.
+	 * Atom names are unique for each unique atom in a group.
+	 * @param groupInd The index of the group specified in {@link #getGroupIndices()}.
+	 * @return A list of strings for the atom names. 
+	 * */
+	String[] getGroupAtomNames(int groupInd);
+
+	/** Returns the element names (e.g. C is carbon) for the group specified in {@link #getGroupIndices()}.
+	 * @param groupInd The index of the group specified in {@link #getGroupIndices()}.
+	 * @return A list of strings for the element information. 
+	 * */
+	String[] getGroupElementNames(int groupInd);	
+
+	/** Returns the bond orders for the group specified in {@link #getGroupIndices()}.
+	 * A list of integers indicating the bond orders
+	 * @param groupInd The index of the group specified in {@link #getGroupIndices()}.
+	 * @return A list of integers (1,2 or 3) indicating the bond orders. 
+	 * */
+	int[] getGroupBondOrders(int groupInd);
+
+	/** Returns the zero-indexed bond indices (in pairs) for the group specified in {@link #getGroupIndices()}.
+	 * (e.g. 0,1 means there is bond between atom 0 and 1).
+	 * @param groupInd The index of the group specified in {@link #getGroupIndices()}.
+	 * @return A list of integers specifying the bond indices (within the group). Indices are zero indexed.
+	 * */
+	int[] getGroupBondIndices(int groupInd);
+
+	/** Returns the atom charges for the group specified in {@link #getGroupIndices()}.
+	 * @param groupInd The index of the group specified in {@link #getGroupIndices()}.
+	 * @return A list of integers indicating the atomic charge for each atom in the group.
+	 */
+	int[] getGroupAtomCharges(int groupInd);
+
+	/** Returns the single letter amino acid code for the group specified in {@link #getGroupIndices()}.
+	 * @param groupInd The index of the group specified in {@link #getGroupIndices()}.
+	 * @return A string indicating the single letter amino acid
+	 */
+	String getGroupSingleLetterCode(int groupInd);
+
+	/** Returns the chemical componenet type for the group specified in {@link #getGroupIndices()}.
+	 * @param groupInd The index of the group specified in {@link #getGroupIndices()}.
+	 * @return A string (taken from the chemical component dictionary) indicating 
+	 * the type of the group. Corresponds to -> http://mmcif.wwpdb.org/dictionaries/mmcif_pdbx.dic/Items/_chem_comp.type.html
+	 */
+	String getGroupChemCompType(int groupInd);
 
 	/**
 	 * Returns an array containing indices of all groups in the structure as used in {@link #getGroupMap()}.
@@ -186,11 +237,37 @@ public interface DataApiInterface {
 	String getMmtfProducer();
 
 	/**
-	 * Returns an array with all {@link Entity} objects for the structure.
-	 * The sequences can be obtained from the Entities.
-	 * @return
+	 * @return The number of entities in the Structure 
 	 */
-	Entity[] getEntityList();
+	int getNumEntities();
+	
+	/**
+	 * Returns the entity description for the entity specified by the index.
+	 * @param The index of this entity.
+	 * @return The description based on the PDBx model.
+	 */
+    String getEntityDescription(int entityInd);
+    
+	/**
+	 * Returns the the type (polymer, non-polymer, water) for the entity specified by the index.
+	 * @param The index of this entity.
+	 * @return The type (polymer, non-polymer, water)
+	 */ 
+    String getEntityType(int entityInd);
+    
+	/**
+	 * Returns the chain indices for the entity specified by the index.
+	 * @param The index of this entity.
+	 * @return The chain index list - referencing the entity to the chains.
+	 */    
+    int[] getEntityChainIndexList(int entityInd);
+    
+	/**
+	 * Returns the sequence for the entity specified by the index.
+	 * @param The index of this entity.
+	 * @return The one letter sequence for this entity. Empty string if no sequence is applicable.
+	 */
+    String getEntitySequence(int entityInd);
 
 	/**
 	 * Returns the four character PDB id of the structure.
@@ -203,54 +280,54 @@ public interface DataApiInterface {
 	 * @return the number of models
 	 */
 	int getNumModels();
-	
+
 	/**
 	 * Returns the number of chains (for all models) in the structure.
 	 * @return the number of chains for all models
 	 * @see #getChainsPerModel()
 	 */
 	int getNumChains();
-	
+
 	/**
 	 * Returns the number of groups (residues) in the structure that have
 	 * experimentally determined 3D coordinates.
 	 * @return the number of residues in the structure, counting all models and chains
 	 */
 	int getNumResidues();
-	
+
 
 	/**
 	 * Returns the number of atoms in the structure.
 	 * @return the number of atoms in the structure, counting all models and chains
 	 */
 	int getNumAtoms();
-	
-	
+
+
 	/**
 	 * Returns the Rfree (if available) of the dataset.
 	 * @return the Rfree value or {@value MmtfBean#UNAVAILABLE_R_VALUE} if unavailable
 	 */
 	float getRfree();
-	
+
 	/**
 	 * Returns the Resolution (if available) of the dataset.
 	 * @return the resolution value in Angstroms or {@value MmtfBean#UNAVAILABLE_R_VALUE} if unavailable
 	 */
 	float getResolution();
-	
+
 	/**
 	 * Returns the Rwork (if available) of the dataset.
 	 * @return the Rwork value or {@value MmtfBean#UNAVAILABLE_R_VALUE} if unavailable
 	 */
 	float getRwork();
-	
-	
+
+
 	/**
 	 * Returns the title of the structure.
 	 * @return
 	 */
 	String getTitle();
-	
+
 	/**
 	 * Returns the experimental methods as a list of strings. Normally only one 
 	 * experimental method is available, but structures solved with hybrid methods will

--- a/mmtf-api/src/main/java/org/rcsb/mmtf/api/DataApiInterface.java
+++ b/mmtf-api/src/main/java/org/rcsb/mmtf/api/DataApiInterface.java
@@ -2,8 +2,6 @@ package org.rcsb.mmtf.api;
 
 import java.util.List;
 
-import org.rcsb.mmtf.dataholders.BioAssemblyData;
-
 /**
  * An interface describing the data API.
  * 
@@ -206,11 +204,36 @@ public interface DataApiInterface {
 	float[] getUnitCell();
 
 	/**
-	 * Returns a list of {@link BioAssemblyData}s corresponding to the structure.
-	 * @return
+	 * Returns the number of bioassemblies in this structure.
+	 * @return an integer specifying the number of bioassemblies.
 	 */
-	List<BioAssemblyData> getBioAssemblyList();
+	int getNumBioassemblies();
 
+	/**
+	 * Returns the number of transformations in a given bioassembly.
+	 * @param an integer specifying the bioassembly index (zero indexed).
+	 * @return an integer specifying of transformations in a given bioassembly.
+	 */
+	int getNumTransInBioassembly(int bioassemblyIndex);
+	
+	/**
+	 * Returns the list of chain ids for the given transformation for the given bioassembly.
+	 * @param an integer specifying the bioassembly index (zero indexed).
+	 * @param an integer specifying the  index (zero indexed) for the desired transformation.
+	 * @return a list of strings showing the chains involved in this transformation.
+	 */
+	String[] getChainIdListForTrans(int bioassemblyIndex, int transformationIndex);
+
+	
+	/**
+	 * Returns the transformation matrix for the given transformation for the given bioassembly.
+	 * @param an integer specifying the bioassembly index (zero indexed).
+	 * @param an integer specifying the  index (zero indexed) for the desired transformation.
+	 * @return the transformation matrix for this transformation.
+	 */
+	double[] getTransMatrixForTrans(int bioassemblyIndex, int transformationIndex);
+	
+	
 	/**
 	 * Returns an array of inter-group bonds represented with 2 consecutive atom 
 	 * indices in the array.

--- a/mmtf-api/src/main/java/org/rcsb/mmtf/api/DataApiInterface.java
+++ b/mmtf-api/src/main/java/org/rcsb/mmtf/api/DataApiInterface.java
@@ -179,10 +179,10 @@ public interface DataApiInterface {
 	String[] getChainNames();
 
 	/**
-	 * Returns an array containing the number of chains (polymeric/non-polymeric/water) in each model.
-	 * @return an array of length the number of models in the structure, obtainable with {@link #getNumModels()}
+	 * Returns an integer containing the number of chains (polymeric/non-polymeric/water) in each model.
+	 * @return an integer of length the number of models in the structure, obtainable with {@link #getNumModels()}
 	 */
-	int[] getChainsPerModel();
+	int getChainsPerModel();
 
 	/**
 	 * Returns an array containing the number of groups (residues) in each chain.

--- a/mmtf-api/src/main/java/org/rcsb/mmtf/api/StructureDecoderInterface.java
+++ b/mmtf-api/src/main/java/org/rcsb/mmtf/api/StructureDecoderInterface.java
@@ -2,8 +2,6 @@ package org.rcsb.mmtf.api;
 
 import java.util.List;
 
-import org.rcsb.mmtf.dataholders.BioAssemblyData;
-
 /**
  * Interface to inflate a given MMTF data source.
  *
@@ -73,11 +71,11 @@ public interface StructureDecoderInterface {
 
 
   /**
-   * Sets the Bioassembly information for the structure.
+   * Sets a single Bioassembly transformation to a structure. bioAssemblyId indicates the index of the bioassembly.
    *
    * @param inputBioassemblies
    */
-  void setBioAssemblyList(List<BioAssemblyData> inputBioAssemblies);
+  void setBioAssemblyTrans(int bioAssemblyId, String[] inputChainIds, double[] inputTransform);
 
   /**
    * Sets the space group and unit cell information.

--- a/mmtf-common/src/main/java/org/rcsb/mmtf/dataholders/MmtfBean.java
+++ b/mmtf-common/src/main/java/org/rcsb/mmtf/dataholders/MmtfBean.java
@@ -2,7 +2,6 @@ package org.rcsb.mmtf.dataholders;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -72,9 +71,8 @@ public class MmtfBean implements Serializable {
 	/** The bond order list. */
 	private byte[] bondOrderList;
 
-	/** The group map. */
-	// Map of all the data
-	private  Map<Integer, PDBGroup> groupMap;
+	/** The list of different PDBGroups in the structure. */
+	private  PDBGroup[] groupList;
 
 	/** The x coord big. 4 byte integers in pairs. */
 	private byte[] xCoordBig;
@@ -519,8 +517,8 @@ public class MmtfBean implements Serializable {
 	 *
 	 * @return the group map
 	 */
-	public final Map<Integer, PDBGroup> getGroupMap() {
-		return groupMap;
+	public final PDBGroup[] getGroupList() {
+		return groupList;
 	}
 
 	/**
@@ -528,8 +526,8 @@ public class MmtfBean implements Serializable {
 	 *
 	 * @param inputGroupMap the group map
 	 */
-	public final void setGroupMap(final Map<Integer, PDBGroup> inputGroupMap) {
-		this.groupMap = inputGroupMap;
+	public final void setGroupList(final PDBGroup[] inputGroupMap) {
+		this.groupList = inputGroupMap;
 	}
 
 	/**

--- a/mmtf-common/src/main/java/org/rcsb/mmtf/dataholders/MmtfBean.java
+++ b/mmtf-common/src/main/java/org/rcsb/mmtf/dataholders/MmtfBean.java
@@ -44,8 +44,11 @@ public class MmtfBean implements Serializable {
 	/** The number of atoms. */
 	private int numAtoms;
 
-	/** The number of chains per model. */
-	private int[] chainsPerModel;
+	/** The number of chains per model. Assumes model homogenity. */
+	private int chainsPerModel;
+	
+	/** The numnber of models */
+	private int numModels;
 
 	/** The internal groups per chain. */
 	private int[] groupsPerChain;
@@ -715,7 +718,7 @@ public class MmtfBean implements Serializable {
 	 *
 	 * @return the list of chains per model.
 	 */
-	public final int[] getChainsPerModel() {
+	public final int getChainsPerModel() {
 		return chainsPerModel;
 	}
 
@@ -724,7 +727,7 @@ public class MmtfBean implements Serializable {
 	 *
 	 * @param inputInternalChainsPerModel the new list of chains per model.
 	 */
-	public final void setChainsPerModel(final int[]
+	public final void setChainsPerModel(final int
 			inputInternalChainsPerModel) {
 		this.chainsPerModel = inputInternalChainsPerModel;
 	}
@@ -808,6 +811,22 @@ public class MmtfBean implements Serializable {
    */
   public void setEntityList(Entity[] entityList) {
 	  this.entityList = entityList;
+  }
+
+  /**
+   * Get the number of models in the structure.
+   * @return An integer specifying the number of models in the structure.
+   */
+  public int getNumModels() {
+		return numModels;
+  }
+	
+  /**
+   * Set the number of models in the structure.
+   * @param An integer specifying the number of models in the structure.
+   */
+  public void setNumModels(int numModels) {
+		this.numModels = numModels;
   }
 
 }

--- a/mmtf-decoder/src/main/java/org/rcsb/mmtf/decoder/DecodeStructure.java
+++ b/mmtf-decoder/src/main/java/org/rcsb/mmtf/decoder/DecodeStructure.java
@@ -79,7 +79,8 @@ public class DecodeStructure {
 	 * Add the main atomic information to the data model
 	 */
 	private void addAtomicInformation() {
-		for (int modelChains: dataApi.getChainsPerModel()) {
+		int modelChains = dataApi.getNumChains();
+		for (modelCounter=0; modelCounter<dataApi.getNumModels(); modelCounter++) {
 			structInflator.setModelInfo(modelCounter, modelChains);
 			// A list to check if we need to set or update the chains
 			chainIdSet = new HashSet<>();
@@ -87,7 +88,6 @@ public class DecodeStructure {
 			for (int chainIndex = chainCounter; chainIndex < totChainsThisModel;  chainIndex++) {
 				addOrUpdateChainInfo(chainIndex);
 			}
-			modelCounter++;
 		}		
 	}
 

--- a/mmtf-decoder/src/main/java/org/rcsb/mmtf/decoder/DecodeStructure.java
+++ b/mmtf-decoder/src/main/java/org/rcsb/mmtf/decoder/DecodeStructure.java
@@ -6,6 +6,8 @@ import java.util.Set;
 
 import org.rcsb.mmtf.api.DataApiInterface;
 import org.rcsb.mmtf.api.StructureDecoderInterface;
+import org.rcsb.mmtf.dataholders.BioAssemblyData;
+import org.rcsb.mmtf.dataholders.BioAssemblyTrans;
 import org.rcsb.mmtf.dataholders.Entity;
 import org.rcsb.mmtf.dataholders.PDBGroup;
 
@@ -17,14 +19,14 @@ import org.rcsb.mmtf.dataholders.PDBGroup;
  */
 public class DecodeStructure {
 
-	
+
 
 	/** The struct inflator. */
 	private StructureDecoderInterface structInflator;
 
 	/** The api to the data */
 	private DataApiInterface dataApi;
-	
+
 	/* 
 	 * Initialise the counters
 	 */
@@ -77,7 +79,7 @@ public class DecodeStructure {
 		// Now do any required cleanup
 		structInflator.cleanUpStructure();
 	}
-	
+
 	/**
 	 * Add the main atomic information to the data model
 	 */
@@ -252,7 +254,15 @@ public class DecodeStructure {
 	 * Parses the bioassembly data and inputs it to the structure inflator
 	 */
 	private void generateBioAssembly() {
-		structInflator.setBioAssemblyList(dataApi.getBioAssemblyList());    
+		int bioAssemblyId = 0;
+		for (BioAssemblyData bioassembly : dataApi.getBioAssemblyList()) {
+			bioAssemblyId++;
+			List<BioAssemblyTrans> trans = bioassembly.getTransforms();
+			for (BioAssemblyTrans bioAssemblyTrans : trans ) {
+				String[] chainIdList = bioAssemblyTrans.getChainIdList().toArray(new String[0]);
+				structInflator.setBioAssemblyTrans(bioAssemblyId, chainIdList, bioAssemblyTrans.getTransformation());    
+			}
+		}
 	}
 
 

--- a/mmtf-decoder/src/main/java/org/rcsb/mmtf/decoder/DecodeStructure.java
+++ b/mmtf-decoder/src/main/java/org/rcsb/mmtf/decoder/DecodeStructure.java
@@ -1,13 +1,10 @@
 package org.rcsb.mmtf.decoder;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.rcsb.mmtf.api.DataApiInterface;
 import org.rcsb.mmtf.api.StructureDecoderInterface;
-import org.rcsb.mmtf.dataholders.BioAssemblyData;
-import org.rcsb.mmtf.dataholders.BioAssemblyTrans;
 
 /**
  * Decode an MMTF structure using a structure inflator. The class also allows access to the unconsumed but parsed and inflated underlying data.
@@ -250,13 +247,9 @@ public class DecodeStructure {
 	 * Parses the bioassembly data and inputs it to the structure inflator
 	 */
 	private void generateBioAssembly() {
-		int bioAssemblyId = 0;
-		for (BioAssemblyData bioassembly : dataApi.getBioAssemblyList()) {
-			bioAssemblyId++;
-			List<BioAssemblyTrans> trans = bioassembly.getTransforms();
-			for (BioAssemblyTrans bioAssemblyTrans : trans ) {
-				String[] chainIdList = bioAssemblyTrans.getChainIdList().toArray(new String[0]);
-				structInflator.setBioAssemblyTrans(bioAssemblyId, chainIdList, bioAssemblyTrans.getTransformation());    
+		for (int i=0; i<dataApi.getNumBioassemblies(); i++) {
+			for(int j=0; j<dataApi.getNumTransInBioassembly(i); j++) {
+				structInflator.setBioAssemblyTrans(i+1, dataApi.getChainIdListForTrans(i, j), dataApi.getTransMatrixForTrans(i,j));    
 			}
 		}
 	}

--- a/mmtf-decoder/src/main/java/org/rcsb/mmtf/decoder/SimpleDataApi.java
+++ b/mmtf-decoder/src/main/java/org/rcsb/mmtf/decoder/SimpleDataApi.java
@@ -351,7 +351,7 @@ public class SimpleDataApi implements DataApiInterface {
 	}
 	
 	public int getNumAtomsInGroup(int groupInd) {
-		return groupMap[groupInd].getAtomCharges().size();
+		return groupMap[groupInd].getAtomInfo().size()/2;
 	}
 
 	@Override

--- a/mmtf-decoder/src/main/java/org/rcsb/mmtf/decoder/SimpleDataApi.java
+++ b/mmtf-decoder/src/main/java/org/rcsb/mmtf/decoder/SimpleDataApi.java
@@ -268,11 +268,6 @@ public class SimpleDataApi implements DataApiInterface {
 	}
 
 	@Override
-	public List<BioAssemblyData> getBioAssemblyList() {
-		return bioAssembly;
-	}
-
-	@Override
 	public int[] getInterGroupBondIndices() {
 		return interGroupBondIndices;
 	}
@@ -446,6 +441,26 @@ public class SimpleDataApi implements DataApiInterface {
 	@Override
 	public int getNumEntities() {
 		return entityList.length;
+	}
+
+	@Override
+	public int getNumBioassemblies() {
+		return bioAssembly.size();
+	}
+
+	@Override
+	public int getNumTransInBioassembly(int bioassemblyIndex) {
+		return bioAssembly.get(bioassemblyIndex).getTransforms().size();
+	}
+
+	@Override
+	public String[] getChainIdListForTrans(int bioassemblyIndex, int transformationIndex) {
+		return bioAssembly.get(bioassemblyIndex).getTransforms().get(transformationIndex).getChainIdList().toArray(new String[0]);
+	}
+
+	@Override
+	public double[] getTransMatrixForTrans(int bioassemblyIndex, int transformationIndex) {
+		return bioAssembly.get(bioassemblyIndex).getTransforms().get(transformationIndex).getTransformation();
 	}
 
 

--- a/mmtf-decoder/src/main/java/org/rcsb/mmtf/decoder/SimpleDataApi.java
+++ b/mmtf-decoder/src/main/java/org/rcsb/mmtf/decoder/SimpleDataApi.java
@@ -132,8 +132,8 @@ public class SimpleDataApi implements DataApiInterface {
 	/** The public facing chain ids*/
 	private String[] publicChainIds;
 
-	/** The number of chains per model*/
-	private int[] chainsPerModel;
+	/** The number of chains per model. Assumes model homogenity.*/
+	private int chainsPerModel;
 
 	/** The number of groups per (internal) chain*/
 	private int[] groupsPerChain;
@@ -185,6 +185,9 @@ public class SimpleDataApi implements DataApiInterface {
 
 	/** The list of experimental methods. */
 	private List<String> experimentalMethods;
+	
+	/** The number of models in the structure. */
+	private int numModels;
 	
 	@Override
 	public float[] getXcoords() {
@@ -247,7 +250,7 @@ public class SimpleDataApi implements DataApiInterface {
 	}
 
 	@Override
-	public int[] getChainsPerModel() {
+	public int getChainsPerModel() {
 		return chainsPerModel;
 	}
 
@@ -308,7 +311,7 @@ public class SimpleDataApi implements DataApiInterface {
 	
 	@Override
 	public int getNumModels() {	
-		return this.chainsPerModel.length;
+		return this.numModels;
 	}
 
 	@Override

--- a/mmtf-decoder/src/main/java/org/rcsb/mmtf/decoder/SimpleDataApi.java
+++ b/mmtf-decoder/src/main/java/org/rcsb/mmtf/decoder/SimpleDataApi.java
@@ -3,7 +3,6 @@ package org.rcsb.mmtf.decoder;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.msgpack.jackson.dataformat.MessagePackFactory;
 import org.rcsb.mmtf.api.DataApiInterface;
@@ -59,7 +58,7 @@ public class SimpleDataApi implements DataApiInterface {
 			// Get the groupNumber
 			groupNum = intRunLengthDelta.decompressByteArray(
 					inputData.getGroupIdList());
-			groupMap = inputData.getGroupMap();
+			groupMap = inputData.getGroupList();
 			// Get the seqRes groups
 			seqResGroupList = intRunLengthDelta.decompressByteArray(inputData.getSeqResIdList());
 			// Get the number of chains per model
@@ -122,7 +121,7 @@ public class SimpleDataApi implements DataApiInterface {
 	private int[] groupNum;
 
 	/** The group map. */
-	private Map<Integer, PDBGroup> groupMap;
+	private PDBGroup[] groupMap;
 
 	/** The group list. */
 	private int[] groupList;
@@ -344,16 +343,16 @@ public class SimpleDataApi implements DataApiInterface {
 
 	@Override
 	public String getGroupName(int groupInd) {
-		return groupMap.get(groupInd).getGroupName();
+		return groupMap[groupInd].getGroupName();
 	}
 	
 	public int getNumAtomsInGroup(int groupInd) {
-		return groupMap.get(groupInd).getAtomCharges().size();
+		return groupMap[groupInd].getAtomCharges().size();
 	}
 
 	@Override
 	public String[] getGroupAtomNames(int groupInd) {
-		List<String> atomInfo =  groupMap.get(groupInd).getAtomInfo();
+		List<String> atomInfo =  groupMap[groupInd].getAtomInfo();
 		String[] outList = new String[atomInfo.size()/2];
 		int counter = 0;
 		for (int i=1; i<atomInfo.size(); i+=2){
@@ -365,7 +364,7 @@ public class SimpleDataApi implements DataApiInterface {
 
 	@Override
 	public String[] getGroupElementNames(int groupInd) {
-		List<String> atomInfo =  groupMap.get(groupInd).getAtomInfo();
+		List<String> atomInfo =  groupMap[groupInd].getAtomInfo();
 		String[] outList = new String[atomInfo.size()/2];
 		int counter = 0;
 		for (int i=0; i<atomInfo.size(); i+=2){
@@ -377,28 +376,28 @@ public class SimpleDataApi implements DataApiInterface {
 
 	@Override
 	public int[] getGroupBondOrders(int groupInd) {
-		return convertToIntList(groupMap.get(groupInd).getBondOrders());
+		return convertToIntList(groupMap[groupInd].getBondOrders());
 
 	}
 
 	@Override
 	public int[] getGroupBondIndices(int groupInd) {
-		return convertToIntList(groupMap.get(groupInd).getBondIndices());
+		return convertToIntList(groupMap[groupInd].getBondIndices());
 	}
 
 	@Override
 	public int[] getGroupAtomCharges(int groupInd) {
-		return convertToIntList(groupMap.get(groupInd).getAtomCharges());
+		return convertToIntList(groupMap[groupInd].getAtomCharges());
 	}
 
 	@Override
 	public String getGroupSingleLetterCode(int groupInd) {
-		return groupMap.get(groupInd).getSingleLetterCode();
+		return groupMap[groupInd].getSingleLetterCode();
 	}
 
 	@Override
 	public String getGroupChemCompType(int groupInd) {
-		return groupMap.get(groupInd).getChemCompType();
+		return groupMap[groupInd].getChemCompType();
 	}
 	
 	

--- a/mmtf-decoder/src/main/java/org/rcsb/mmtf/decoder/SimpleDataApi.java
+++ b/mmtf-decoder/src/main/java/org/rcsb/mmtf/decoder/SimpleDataApi.java
@@ -42,6 +42,7 @@ public class SimpleDataApi implements DataApiInterface {
 		
 		// Get the data
 		try {
+			numModels = inputData.getNumModels();
 			groupList = decoderUtils.bytesToInts(inputData.getGroupTypeList());
 			// Read the byte arrays as int arrays
 			cartnX = decoderUtils.decodeIntsToFloats(deltaDecompress.decompressByteArray(inputData.getxCoordBig(), inputData.getxCoordSmall()), MmtfBean.COORD_DIVIDER);

--- a/mmtf-decoder/src/main/java/org/rcsb/mmtf/decoder/SimpleDataApi.java
+++ b/mmtf-decoder/src/main/java/org/rcsb/mmtf/decoder/SimpleDataApi.java
@@ -233,11 +233,6 @@ public class SimpleDataApi implements DataApiInterface {
 	}
 
 	@Override
-	public Map<Integer, PDBGroup> getGroupMap() {
-		return groupMap;
-	}
-
-	@Override
 	public int[] getGroupIndices() {
 		return groupList;
 	}
@@ -303,11 +298,6 @@ public class SimpleDataApi implements DataApiInterface {
 	}
 
 	@Override
-	public Entity[] getEntityList() {
-		return entityList;
-	}
-
-	@Override
 	public String getPdbId() {
 		return pdbId;
 	}
@@ -355,6 +345,107 @@ public class SimpleDataApi implements DataApiInterface {
 	@Override
 	public List<String> getExperimentalMethods() {
 		return experimentalMethods;
+	}
+
+	@Override
+	public String getGroupName(int groupInd) {
+		return groupMap.get(groupInd).getGroupName();
+	}
+	
+	public int getNumAtomsInGroup(int groupInd) {
+		return groupMap.get(groupInd).getAtomCharges().size();
+	}
+
+	@Override
+	public String[] getGroupAtomNames(int groupInd) {
+		List<String> atomInfo =  groupMap.get(groupInd).getAtomInfo();
+		String[] outList = new String[atomInfo.size()/2];
+		int counter = 0;
+		for (int i=1; i<atomInfo.size(); i+=2){
+			outList[counter] = atomInfo.get(i);
+			counter++;
+		}
+		return outList;
+	}
+
+	@Override
+	public String[] getGroupElementNames(int groupInd) {
+		List<String> atomInfo =  groupMap.get(groupInd).getAtomInfo();
+		String[] outList = new String[atomInfo.size()/2];
+		int counter = 0;
+		for (int i=0; i<atomInfo.size(); i+=2){
+			outList[counter] = atomInfo.get(i);
+			counter++;
+		}
+		return outList;
+	}
+
+	@Override
+	public int[] getGroupBondOrders(int groupInd) {
+		return convertToIntList(groupMap.get(groupInd).getBondOrders());
+
+	}
+
+	@Override
+	public int[] getGroupBondIndices(int groupInd) {
+		return convertToIntList(groupMap.get(groupInd).getBondIndices());
+	}
+
+	@Override
+	public int[] getGroupAtomCharges(int groupInd) {
+		return convertToIntList(groupMap.get(groupInd).getAtomCharges());
+	}
+
+	@Override
+	public String getGroupSingleLetterCode(int groupInd) {
+		return groupMap.get(groupInd).getSingleLetterCode();
+	}
+
+	@Override
+	public String getGroupChemCompType(int groupInd) {
+		return groupMap.get(groupInd).getChemCompType();
+	}
+	
+	
+	/**
+	 * Get a primitive int[] list from a Java List<>;
+	 * @param inArray The input List<> of Integers
+	 * @return A primitive int[].
+	 */
+	private int[] convertToIntList(List<Integer> inArray) {
+		int[] outArray = new int[inArray.size()];
+		for (int i=0; i<inArray.size(); i++) {
+			outArray[i] = inArray.get(i);
+		}
+		return outArray;
+	}
+
+	@Override
+	public String getEntityDescription(int entityInd) {
+		return entityList[entityInd].getDescription();
+	}
+
+	@Override
+	public String getEntityType(int entityInd) {
+		return entityList[entityInd].getType();
+
+	}
+
+	@Override
+	public int[] getEntityChainIndexList(int entityInd) {
+		return entityList[entityInd].getChainIndexList();
+
+	}
+
+	@Override
+	public String getEntitySequence(int entityInd) {
+		return entityList[entityInd].getSequence();
+
+	}
+
+	@Override
+	public int getNumEntities() {
+		return entityList.length;
 	}
 
 

--- a/mmtf-decoder/src/main/java/org/rcsb/mmtf/examples/HelloWorld.java
+++ b/mmtf-decoder/src/main/java/org/rcsb/mmtf/examples/HelloWorld.java
@@ -1,7 +1,6 @@
 package org.rcsb.mmtf.examples;
 
 import org.rcsb.mmtf.api.DataApiInterface;
-import org.rcsb.mmtf.dataholders.PDBGroup;
 
 public class HelloWorld {
 
@@ -9,8 +8,7 @@ public class HelloWorld {
 		HandleIO handleIO = new HandleIO();
 		DataApiInterface dataApi = handleIO.getDataApiFromUrlOrFile("4cup");
 		System.out.println("PDB Code: "+dataApi.getPdbId()+" has "+dataApi.getNumChains()+" chains");
-		PDBGroup pdbGroup = dataApi.getGroupMap().get(0);
-		System.out.println("HET group "+pdbGroup.getGroupName()+" has the following atomic charges: "+pdbGroup.getAtomCharges());
+		System.out.println("HET group "+dataApi.getGroupName(0)+" has the following atomic charges: "+dataApi.getGroupAtomCharges(0));
 		System.out.println("PDB Code: "+dataApi.getPdbId()+" has "+dataApi.getBioAssemblyList().size()+" bioassemblies");
 	}
 

--- a/mmtf-decoder/src/main/java/org/rcsb/mmtf/examples/HelloWorld.java
+++ b/mmtf-decoder/src/main/java/org/rcsb/mmtf/examples/HelloWorld.java
@@ -9,7 +9,7 @@ public class HelloWorld {
 		DataApiInterface dataApi = handleIO.getDataApiFromUrlOrFile("4cup");
 		System.out.println("PDB Code: "+dataApi.getPdbId()+" has "+dataApi.getNumChains()+" chains");
 		System.out.println("HET group "+dataApi.getGroupName(0)+" has the following atomic charges: "+dataApi.getGroupAtomCharges(0));
-		System.out.println("PDB Code: "+dataApi.getPdbId()+" has "+dataApi.getBioAssemblyList().size()+" bioassemblies");
+		System.out.println("PDB Code: "+dataApi.getPdbId()+" has "+dataApi.getNumBioassemblies()+" bioassemblies");
 	}
 
 }

--- a/mmtf-encoder/pom.xml
+++ b/mmtf-encoder/pom.xml
@@ -29,7 +29,7 @@
 		<dependency>
 			<groupId>org.biojava</groupId>
 			<artifactId>biojava-structure</artifactId>
-            <version>5.0.0-alpha3</version>
+            <version>5.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.msgpack</groupId>

--- a/mmtf-encoder/src/main/java/org/rcsb/mmtf/biojavaencoder/EncoderUtils.java
+++ b/mmtf-encoder/src/main/java/org/rcsb/mmtf/biojavaencoder/EncoderUtils.java
@@ -149,6 +149,7 @@ public class EncoderUtils implements Serializable {
 		thisDistBeanTot.setBioAssemblyList(inHeader.getBioAssembly());
 		// Now set this extra header information
 		thisDistBeanTot.setTitle(inHeader.getTitle());
+		thisDistBeanTot.setNumModels(inStruct.getNumModels());
 		// Now add the byte arrays to the bean
 		addByteArrs(thisDistBeanTot, bioBean);
 		// Now set the version

--- a/mmtf-encoder/src/main/java/org/rcsb/mmtf/biojavaencoder/EncoderUtils.java
+++ b/mmtf-encoder/src/main/java/org/rcsb/mmtf/biojavaencoder/EncoderUtils.java
@@ -9,8 +9,10 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.zip.GZIPOutputStream;
 
@@ -38,6 +40,7 @@ import org.rcsb.mmtf.dataholders.HeaderBean;
 import org.rcsb.mmtf.dataholders.MmtfBean;
 import org.rcsb.mmtf.dataholders.NoFloatDataStruct;
 import org.rcsb.mmtf.dataholders.NoFloatDataStructBean;
+import org.rcsb.mmtf.dataholders.PDBGroup;
 import org.rcsb.mmtf.gitversion.GetRepoState;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -141,7 +144,7 @@ public class EncoderUtils implements Serializable {
 		thisDistBeanTot.setNumBonds(inHeader.getNumBonds());
 		// Now get the Xtalographic info from this header
 		thisDistBeanTot.setSpaceGroup(inHeader.getSpaceGroup());
-		thisDistBeanTot.setGroupMap(inStruct.getGroupMap());
+		thisDistBeanTot.setGroupList(genGroupList(inStruct.getGroupMap()));
 		thisDistBeanTot.setUnitCell(inHeader.getUnitCell());
 		thisDistBeanTot.setBioAssemblyList(inHeader.getBioAssembly());
 		// Now set this extra header information
@@ -152,6 +155,20 @@ public class EncoderUtils implements Serializable {
 		thisDistBeanTot.setMmtfProducer("RCSB-PDB Generator---version: "+grs.getCurrentVersion());
 		return thisDistBeanTot;
 	}
+
+	/**
+	 * Returns a PDBGroupList from a GroupMap. Uses the key of the map as the index in the list.
+	 * @param groupMap The input map of Integer -> PDBGroup
+	 * @return A list of PDBGroups, where the previous keys are used as indices.
+	 */
+	private PDBGroup[] genGroupList(Map<Integer, PDBGroup> groupMap) {
+		PDBGroup[] outGroupList = new PDBGroup[Collections.max(groupMap.keySet())+1];
+		for (int key : groupMap.keySet()) {
+			outGroupList[key] = groupMap.get(key);
+		}
+		return outGroupList;
+	}
+
 
 	/**
 	 * Add the required bytearrays to an mmtfbean.

--- a/mmtf-encoder/src/main/java/org/rcsb/mmtf/biojavaencoder/ParseFromBiojava.java
+++ b/mmtf-encoder/src/main/java/org/rcsb/mmtf/biojavaencoder/ParseFromBiojava.java
@@ -209,20 +209,11 @@ public class ParseFromBiojava {
 		int atomCounter = 0;
 		chainCounter = 0;
 		int resCounter = 0;
-		int totAsymChains = 0;
 		// Get the total number of chains
-		for (int i=0; i<numModels; i++){		
-			totAsymChains += bioJavaStruct.getChains(i).size();
-		}
+		int totAsymChains = bioJavaStruct.getChains().size();
 		// Generate the group map for Calphas
 		calphaHashCodeToGroupMap = new HashMap<Integer, PDBGroup>();
 		// Get these lists to keep track of everthing - and to give  a datastrcutrue at the end
-		// List of chains per model
-		int chainsPerModel = -1;
-		int internalChainsPerModel = -1;
-		// Set this list
-		headerStruct.setChainsPerModel(chainsPerModel);
-		headerStruct.setAsymChainsPerModel(internalChainsPerModel);
 		byte[] charChainList = new byte[totAsymChains*4];
 		byte[] charInternalChainList = new byte[totAsymChains*4];
 		headerStruct.setChainList(charChainList);
@@ -242,7 +233,7 @@ public class ParseFromBiojava {
 		int bondCounter = 0;
 
 		calphaGroupsPerChain = new int[totAsymChains];
-		for(int i=0; i<totAsymChains; i++){
+		for(int i=0; i<totAsymChains; i++){			
 			calphaGroupsPerChain[i] = 0;
 		}
 		calphaStruct.setGroupsPerChain(calphaGroupsPerChain);
@@ -255,7 +246,6 @@ public class ParseFromBiojava {
 			List<Chain> chains = bioJavaStruct.getModel(i);
 			// Set the PDB Code
 			bioStruct.setPdbCode(bioJavaStruct.getPDBCode());
-			ArrayList<String> chainList = new ArrayList<String>();
 			// Get the number of unique ones
 			Set<String> chainIdSet = new HashSet<String>();
 			for(Chain c : chains) {
@@ -264,104 +254,93 @@ public class ParseFromBiojava {
 			}
 			// Set the number of chains in each model (assumes homogenity).
 			if (i==0) {
-				internalChainsPerModel = chains.size();
-			}
-			if (i==0) {
-				chainsPerModel = chainIdSet.size();
+				headerStruct.setAsymChainsPerModel(chains.size());
+				headerStruct.setChainsPerModel(chainIdSet.size());
 			}
 
 			// Take the atomic information and place in a Hashmap
 			for (Chain biojavaChain: chains) {	
 				// Get the seq res groups for this chain
 				List<Group> seqResGroups = biojavaChain.getSeqResGroups();
-				// Set the sequence  - if it's the first model...
+				// Set the sequence and chain information  - if it's the first model...
 				if(i==0){
-					headerStruct.getSequence().add(biojavaChain.getSeqResSequence());
+					headerStruct.getSequence().add(biojavaChain.getSeqResSequence());				
+					// Set the auth chain id
+					setChainId(biojavaChain.getInternalChainID(), charChainList, chainCounter);
+					// Set the asym chain id	
+					setChainId(biojavaChain.getChainID(), charInternalChainList, chainCounter);
+					// Set the number of groups per chain
+					groupsPerChain[chainCounter] += biojavaChain.getAtomGroups().size();
+					// Set the number of groups per internal chain
+					groupsPerInternalChain[chainCounter] = biojavaChain.getAtomGroups().size();				
 				}
-				// Set the auth chain id
-				setChainId(biojavaChain.getInternalChainID(), charChainList, chainCounter);
-				// Set the asym chain id	
-				setChainId(biojavaChain.getChainID(), charInternalChainList, chainCounter);
-				// Set the number of groups per chain
-				groupsPerChain[chainCounter] += biojavaChain.getAtomGroups().size();
-				// Set the number of groups per internal chain
-				groupsPerInternalChain[chainCounter] = biojavaChain.getAtomGroups().size();				
-				// Add this chain to the list
-				chainList.add(biojavaChain.getChainID());
-				// Get the groups
 				String currentChainId = biojavaChain.getChainID();
 				int numBonds = 0;
 				for (Group loopGroup : biojavaChain.getAtomGroups()) {
 					currentGroup = loopGroup;
 					// Set the seq res group id 
-					if(i==0){
-						headerStruct.getSeqResGroupIds().add(seqResGroups.indexOf(currentGroup));
-					}
-					// Get the pdb id
-					String res_id = currentGroup.getPDBName();
 					// Get the atoms for this group
 					List<Atom> atomsInThisGroup = encoderUtils.getAtomsForGroup(currentGroup);
-					// Get any bonds between groups
-					getInterGroupBond(atomsInThisGroup, totAtoms, atomCounter);
-					// Count the number of bonds
-					// Now loop through and get the coords
-
-					// Generate the group level data
-					// Get the 
-					List<String> atomInfo = getAtomInfo(atomsInThisGroup);
-					// Get the atomic info required - bioStruct is the unique identifier of the group 
-					int hashCode = getHashFromStringList(atomInfo);
-					// If we need bioStruct new information 
-					if (hashToRes.containsKey(hashCode)==false){
-						// Make a new group
-						PDBGroup outGroup = new PDBGroup();
-						// Set the one letter code
-						outGroup.setSingleLetterCode(currentGroup.getChemComp().getOne_letter_code());
-						// Set the group type
-						outGroup.setChemCompType(currentGroup.getChemComp().getType());
-						outGroup.setGroupName(atomInfo.remove(0));
-						outGroup.setAtomInfo(atomInfo);
-						// Now get the bond list (lengths, orders and indices)
-						createBondList(atomsInThisGroup, outGroup); 
-						getCharges(atomsInThisGroup, outGroup);
-						// 
-						bioStructMap.put(resCounter, outGroup);
-						hashToRes.put(hashCode, resCounter);
-						bioStruct.getResOrder().add(resCounter);
-						resCounter+=1;
-						numBonds = outGroup.getBondOrders().size();
-					}
-					else{
-						// Add this to the residue order
-						bioStruct.getResOrder().add(hashToRes.get(hashCode));	
-						numBonds = bioStructMap.get(hashToRes.get(hashCode)).getBondOrders().size();
-					}
-					// Add the number of bonds 
-					bondCounter+=numBonds;
-
+					// Residue number needed later.
 					ResidueNumber residueNum = currentGroup.getResidueNumber();
-
-					// bioStruct data item corresponds to the PDB insertion code.
-					Character insertionCode = residueNum.getInsCode();
-					if (insertionCode==null){
-						bioStruct.get_atom_site_pdbx_PDB_ins_code().add(null);
-					}
-					else{
-						bioStruct.get_atom_site_pdbx_PDB_ins_code().add(insertionCode.toString());
-					}
-
+					// Get the pdb id
+					String res_id = currentGroup.getPDBName();
+					// Get the secondary structure
 					SecStrucState props = (SecStrucState) currentGroup.getProperty("secstruc");
-					// Only assign secondary structure for the first model
 					if(i==0){
+						headerStruct.getSeqResGroupIds().add(seqResGroups.indexOf(currentGroup));
+						// Get any bonds between groups
+						getInterGroupBond(atomsInThisGroup, totAtoms, atomCounter);
+						// Count the number of bonds
+						// Get the atom info
+						List<String> atomInfo = getAtomInfo(atomsInThisGroup);
+						// Get the atomic info required - bioStruct is the unique identifier of the group 
+						int hashCode = getHashFromStringList(atomInfo);
+						// If we need bioStruct new information 
+						if (hashToRes.containsKey(hashCode)==false){
+							// Make a new group
+							PDBGroup outGroup = new PDBGroup();
+							// Set the one letter code
+							outGroup.setSingleLetterCode(currentGroup.getChemComp().getOne_letter_code());
+							// Set the group type
+							outGroup.setChemCompType(currentGroup.getChemComp().getType());
+							outGroup.setGroupName(atomInfo.remove(0));
+							outGroup.setAtomInfo(atomInfo);
+							// Now get the bond list (lengths, orders and indices)
+							createBondList(atomsInThisGroup, outGroup); 
+							getCharges(atomsInThisGroup, outGroup);
+							// 
+							bioStructMap.put(resCounter, outGroup);
+							hashToRes.put(hashCode, resCounter);
+							bioStruct.getResOrder().add(resCounter);
+							resCounter+=1;
+							numBonds = outGroup.getBondOrders().size();
+						}
+						else{
+							// Add this to the residue order
+							bioStruct.getResOrder().add(hashToRes.get(hashCode));	
+							numBonds = bioStructMap.get(hashToRes.get(hashCode)).getBondOrders().size();
+						}
+						// Add the number of bonds (only number of bonds in first model).
+						bondCounter+=numBonds;
+						// Set the inserion code
+						Character insertionCode = residueNum.getInsCode();
+						if (insertionCode==null){
+							bioStruct.get_atom_site_pdbx_PDB_ins_code().add(null);
+						}
+						else{
+							bioStruct.get_atom_site_pdbx_PDB_ins_code().add(insertionCode.toString());
+						}
+						// Assign secondary structure info
 						if(props==null){
 							bioStruct.getSecStruct().add(codeHolder.getDsspMap().get("NA"));
 						}
 						else{
 							bioStruct.getSecStruct().add(codeHolder.getDsspMap().get(props.getType().name));
 						}
+						// Now add the residue sequnece number
+						bioStruct.get_atom_site_auth_seq_id().add(residueNum.getSeqNum());
 					}
-					// Now add the residue sequnece number
-					bioStruct.get_atom_site_auth_seq_id().add(residueNum.getSeqNum());
 					// Set whether or not this is a calpha
 					List<Atom> cAlphaGroup = new ArrayList<Atom>();
 					for (Atom currentAtom : atomsInThisGroup) {
@@ -372,8 +351,10 @@ public class ParseFromBiojava {
 						// Increment the atom counter
 						atomCounter+=1;
 					}
-					// Now add this group - if there is something to consider
-					addCalphaGroup(cAlphaGroup, props, residueNum);
+					if (i==0){
+						// Now add this group - if there is something to consider
+						addCalphaGroup(cAlphaGroup, props, residueNum);
+					}
 				}
 				// Increment again by one
 				chainCounter+=1;
@@ -399,15 +380,20 @@ public class ParseFromBiojava {
 		List<EntityInfo> entities = bioJavaStruct.getEntityInfos();
 		// Get the list of chains for all the models
 		List<Chain> structChains = new ArrayList<>();
-		for (int i=0; i < bioJavaStruct.nrModels(); i++) {
-			structChains.addAll(bioJavaStruct.getChains(i));
+		// Only get entity info for the first model
+		structChains.addAll(bioJavaStruct.getChains());
+		List<Chain> bannedChains = new ArrayList<>();
+		for (int i=1; i<bioJavaStruct.nrModels(); i++) {
+			bannedChains.addAll(bioJavaStruct.getChains(i));
 		}
+		
 		Entity[] entityList = new Entity[entities.size()];
 		int entityCounter = 0;
 		for(EntityInfo entityInfo : entities) { 
 			Entity newEntity = new Entity();
 			// Get the indices for the chains in this guy
 			List<Chain> entChains = entityInfo.getChains();
+			entChains.removeAll(bannedChains);
 			int[] indexList = new int[entChains.size()];
 			int counter = 0;
 			for(Chain entChain : entChains) {

--- a/mmtf-encoder/src/main/java/org/rcsb/mmtf/biojavaencoder/ParseFromBiojava.java
+++ b/mmtf-encoder/src/main/java/org/rcsb/mmtf/biojavaencoder/ParseFromBiojava.java
@@ -218,8 +218,8 @@ public class ParseFromBiojava {
 		calphaHashCodeToGroupMap = new HashMap<Integer, PDBGroup>();
 		// Get these lists to keep track of everthing - and to give  a datastrcutrue at the end
 		// List of chains per model
-		int[] chainsPerModel = new int[numModels];
-		int[] internalChainsPerModel = new int[numModels];
+		int chainsPerModel = -1;
+		int internalChainsPerModel = -1;
 		// Set this list
 		headerStruct.setChainsPerModel(chainsPerModel);
 		headerStruct.setAsymChainsPerModel(internalChainsPerModel);
@@ -257,14 +257,18 @@ public class ParseFromBiojava {
 			bioStruct.setPdbCode(bioJavaStruct.getPDBCode());
 			ArrayList<String> chainList = new ArrayList<String>();
 			// Set the number of chains in this model
-			internalChainsPerModel[i] = chains.size();
+			if (i==0) {
+				internalChainsPerModel = chains.size();
+			}
 			// Get the number of unique ones
 			Set<String> chainIdSet = new HashSet<String>();
 			for(Chain c : chains){
 				String intChainId = c.getInternalChainID();
 				chainIdSet.add(intChainId);
 			}
-			chainsPerModel[i] = chainIdSet.size();
+			if (i==0) {
+				chainsPerModel = chainIdSet.size();
+			}
 			// Take the atomic information and place in a Hashmap
 			for (Chain biojavaChain: chains) {	
 				// Get the seq res groups for this chain

--- a/mmtf-encoder/src/main/java/org/rcsb/mmtf/biojavaencoder/ParseFromBiojava.java
+++ b/mmtf-encoder/src/main/java/org/rcsb/mmtf/biojavaencoder/ParseFromBiojava.java
@@ -256,19 +256,20 @@ public class ParseFromBiojava {
 			// Set the PDB Code
 			bioStruct.setPdbCode(bioJavaStruct.getPDBCode());
 			ArrayList<String> chainList = new ArrayList<String>();
-			// Set the number of chains in this model
-			if (i==0) {
-				internalChainsPerModel = chains.size();
-			}
 			// Get the number of unique ones
 			Set<String> chainIdSet = new HashSet<String>();
-			for(Chain c : chains){
+			for(Chain c : chains) {
 				String intChainId = c.getInternalChainID();
 				chainIdSet.add(intChainId);
+			}
+			// Set the number of chains in each model (assumes homogenity).
+			if (i==0) {
+				internalChainsPerModel = chains.size();
 			}
 			if (i==0) {
 				chainsPerModel = chainIdSet.size();
 			}
+
 			// Take the atomic information and place in a Hashmap
 			for (Chain biojavaChain: chains) {	
 				// Get the seq res groups for this chain

--- a/mmtf-encoder/src/main/java/org/rcsb/mmtf/dataholders/BioDataStructBean.java
+++ b/mmtf-encoder/src/main/java/org/rcsb/mmtf/dataholders/BioDataStructBean.java
@@ -29,22 +29,6 @@ public class BioDataStructBean extends NoCoordDataStruct implements BioBean {
 	// The fraction of the atom present at this atom position_
 	protected List<Float> _atom_site_occupancy= new ArrayList<Float>();
 	
-	/** The secondary  structure list. */
-	// An array to store the secondary structure data
-	private List<Integer> secStruct = new ArrayList<Integer>();
-	
-	/** The residue order list. */
-	// An array to store the sequence of residues
-	private List<Integer> resOrder = new ArrayList<Integer>();
-	
-	/** The inter-group bond indicess. */
-	// Arrays to store the indices and bond orders of inter residue bonds
-	private List<Integer> interGroupBondInds = new ArrayList<Integer>();
-	
-	/** The inter-group bond orders. */
-	private List<Integer> interGroupBondOrders = new ArrayList<Integer>();
-	
-	
 	/**
 	 * Gets the _atom_site_id.
 	 *
@@ -156,59 +140,4 @@ public class BioDataStructBean extends NoCoordDataStruct implements BioBean {
 		this._atom_site_occupancy = _atom_site_occupancy;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.rcsb.mmtf.dataholders.NoCoordDataStruct#getResOrder()
-	 */
-	public List<Integer> getResOrder() {
-		return resOrder;
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.rcsb.mmtf.dataholders.NoCoordDataStruct#setResOrder(java.util.List)
-	 */
-	public void setResOrder(List<Integer> resOrder) {
-		this.resOrder = resOrder;
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.rcsb.mmtf.dataholders.NoCoordDataStruct#getSecStruct()
-	 */
-	public List<Integer> getSecStruct() {
-		return secStruct;
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.rcsb.mmtf.dataholders.NoCoordDataStruct#setSecStruct(java.util.List)
-	 */
-	public void setSecStruct(List<Integer> secStruct) {
-		this.secStruct = secStruct;
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.rcsb.mmtf.dataholders.NoCoordDataStruct#getInterGroupBondOrders()
-	 */
-	public List<Integer> getInterGroupBondOrders() {
-		return interGroupBondOrders;
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.rcsb.mmtf.dataholders.NoCoordDataStruct#setInterGroupBondOrders(java.util.List)
-	 */
-	public void setInterGroupBondOrders(List<Integer> interGroupBondOrders) {
-		this.interGroupBondOrders = interGroupBondOrders;
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.rcsb.mmtf.dataholders.NoCoordDataStruct#getInterGroupBondInds()
-	 */
-	public List<Integer> getInterGroupBondInds() {
-		return interGroupBondInds;
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.rcsb.mmtf.dataholders.NoCoordDataStruct#setInterGroupBondInds(java.util.List)
-	 */
-	public void setInterGroupBondInds(List<Integer> interGroupBondInds) {
-		this.interGroupBondInds = interGroupBondInds;
-	}
 }

--- a/mmtf-encoder/src/main/java/org/rcsb/mmtf/dataholders/CalphaDistBean.java
+++ b/mmtf-encoder/src/main/java/org/rcsb/mmtf/dataholders/CalphaDistBean.java
@@ -88,7 +88,7 @@ public class CalphaDistBean {
 	
 	/** The chains per model. */
 	// Add this to store the model information
-	private int[] chainsPerModel;
+	private int chainsPerModel;
 	
 	/** The chain list. */
 	// List to store the chainids
@@ -215,7 +215,7 @@ public class CalphaDistBean {
 	 *
 	 * @return the chains per model
 	 */
-	public int[] getChainsPerModel() {
+	public int getChainsPerModel() {
 		return chainsPerModel;
 	}
 	
@@ -224,7 +224,7 @@ public class CalphaDistBean {
 	 *
 	 * @param chainsPerModel the new chains per model
 	 */
-	public void setChainsPerModel(int[] chainsPerModel) {
+	public void setChainsPerModel(int chainsPerModel) {
 		this.chainsPerModel = chainsPerModel;
 	}
 	

--- a/mmtf-encoder/src/main/java/org/rcsb/mmtf/dataholders/HeaderBean.java
+++ b/mmtf-encoder/src/main/java/org/rcsb/mmtf/dataholders/HeaderBean.java
@@ -71,6 +71,9 @@ public class HeaderBean {
 
 	/** The chains per model. */
 	private int chainsPerModel;
+	
+	/** The number of models. */
+	private int numModels;
 
 	/** The asym chains per model. Assumes model homogenity.*/
 	private int asymChainsPerModel;
@@ -626,5 +629,13 @@ public class HeaderBean {
 
 	public void setEntityList(Entity[] entityList) {
 		this.entityList = entityList;
+	}
+
+	public int getNumModels() {
+		return numModels;
+	}
+
+	public void setNumModels(int numModels) {
+		this.numModels = numModels;
 	}	
 }

--- a/mmtf-encoder/src/main/java/org/rcsb/mmtf/dataholders/HeaderBean.java
+++ b/mmtf-encoder/src/main/java/org/rcsb/mmtf/dataholders/HeaderBean.java
@@ -70,11 +70,10 @@ public class HeaderBean {
 	private List<String> experimentalMethods;
 
 	/** The chains per model. */
-	// Add this to store the model information
-	private int[] chainsPerModel;
+	private int chainsPerModel;
 
-	/** The asym chains per model. */
-	private int[] asymChainsPerModel;
+	/** The asym chains per model. Assumes model homogenity.*/
+	private int asymChainsPerModel;
 
 	/** The chain list. */
 	// List to store the chainids
@@ -214,7 +213,7 @@ public class HeaderBean {
 	 *
 	 * @return the chains per model
 	 */
-	public int[] getChainsPerModel() {
+	public int getChainsPerModel() {
 		return chainsPerModel;
 	}
 
@@ -223,7 +222,7 @@ public class HeaderBean {
 	 *
 	 * @param chainsPerModel the new chains per model
 	 */
-	public void setChainsPerModel(int[] chainsPerModel) {
+	public void setChainsPerModel(int chainsPerModel) {
 		this.chainsPerModel = chainsPerModel;
 	}
 
@@ -520,7 +519,7 @@ public class HeaderBean {
 	 *
 	 * @return the asym chains per model
 	 */
-	public int[] getAsymChainsPerModel() {
+	public int getAsymChainsPerModel() {
 		return asymChainsPerModel;
 	}
 
@@ -529,7 +528,7 @@ public class HeaderBean {
 	 *
 	 * @param asymChainsPerModel the new asym chains per model
 	 */
-	public void setAsymChainsPerModel(int[] asymChainsPerModel) {
+	public void setAsymChainsPerModel(int asymChainsPerModel) {
 		this.asymChainsPerModel = asymChainsPerModel;
 	}
 

--- a/mmtf-update/pom.xml
+++ b/mmtf-update/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>org.biojava</groupId>
 			<artifactId>biojava-structure</artifactId>
-			<version>5.0.0-alpha3</version>
+			<version>5.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>

--- a/mmtf-update/src/main/java/org/rcsb/mmtf/testutils/CheckOnBiojava.java
+++ b/mmtf-update/src/main/java/org/rcsb/mmtf/testutils/CheckOnBiojava.java
@@ -51,6 +51,7 @@ public class CheckOnBiojava {
 
 			if(chainsOne.size()!=chainsTwo.size()){
 				System.out.println("Error - diff number chains: "+structOne.getPDBCode());
+				System.out.println("Model: "+i+ "."+chainsOne.size()+" vs "+chainsTwo.size());
 				return false;
 			}
 			// Now loop over

--- a/mmtf-update/src/main/java/org/rcsb/mmtf/testutils/CheckOnRawApi.java
+++ b/mmtf-update/src/main/java/org/rcsb/mmtf/testutils/CheckOnRawApi.java
@@ -13,7 +13,6 @@ import org.biojava.nbio.structure.Group;
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.io.FileParsingParameters;
 import org.rcsb.mmtf.api.DataApiInterface;
-import org.rcsb.mmtf.dataholders.Entity;
 import org.rcsb.mmtf.decoder.SimpleDataApi;
 
 /**
@@ -22,106 +21,102 @@ import org.rcsb.mmtf.decoder.SimpleDataApi;
  *
  */
 public class CheckOnRawApi {
-  DataApiInterface dataApi;
-  public CheckOnRawApi(byte[] inputData) {
-    dataApi = new SimpleDataApi(inputData);
-  }
-
-  /**
-   * Check that required data is available the way we would expect.
-   * @param biojavaStruct The input structure (parsed from MMCIF) that can be used to compare.
-   * @param params The input file parsing parameters.
-   */
-  public void checkRawDataConsistency(Structure biojavaStruct, FileParsingParameters params) {
-    // Series of tests on expected values from the raw API
-    assertNotEquals(dataApi.getMmtfProducer(), null);
-    assertNotEquals(dataApi.getMmtfVersion(), null);
-    checkIfSeqResInfoSame(biojavaStruct, params);
-    checkIfEntityInfoSame(biojavaStruct);
-    // Check other features in the data
-  }
-
-
-  /**
-   * Test to see if the roundtripped entity data is the same as is found in the MMCIF
-   */
-  public void checkIfEntityInfoSame(Structure biojavaStruct) {    
-
-    // Fist check it's not null
-    assertNotEquals(dataApi.getEntityList(), null);
-    // Second check it's the same length
-    assertEquals(dataApi.getEntityList().length, biojavaStruct.getEntityInfos().size());
-	List<Chain> totChains = new ArrayList<>();
-	for (int i=0; i < biojavaStruct.nrModels(); i++) {
-		totChains.addAll(biojavaStruct.getChains(i));
+	DataApiInterface dataApi;
+	public CheckOnRawApi(byte[] inputData) {
+		dataApi = new SimpleDataApi(inputData);
 	}
-    // Now check it has the same information as BioJava
-    for(int i=0; i<dataApi.getEntityList().length; i++) {
-      EntityInfo biojavaEntity = biojavaStruct.getEntityInfos().get(i);
-      Entity mmtfEntity = dataApi.getEntityList()[i];
-      assertNotEquals(mmtfEntity, null);
-      assertEquals(mmtfEntity.getDescription(), biojavaEntity.getDescription());
-      assertEquals(mmtfEntity.getType(), biojavaEntity.getType().toString());
-      // Now check it maps onto the correct chains
-      List<Chain> bioJavaChains = biojavaEntity.getChains();
-      int[] mmtfList = mmtfEntity.getChainIndexList();
-      assertEquals(mmtfList.length, bioJavaChains.size());
-      int[] testList = new int[bioJavaChains.size()];
-      for(int j=0; j<bioJavaChains.size();j++) {
-        testList[j] = totChains.indexOf(bioJavaChains.get(j));
-      }
-      assertArrayEquals(testList, mmtfList);
 
-    }
-  }
+	/**
+	 * Check that required data is available the way we would expect.
+	 * @param biojavaStruct The input structure (parsed from MMCIF) that can be used to compare.
+	 * @param params The input file parsing parameters.
+	 */
+	public void checkRawDataConsistency(Structure biojavaStruct, FileParsingParameters params) {
+		// Series of tests on expected values from the raw API
+		assertNotEquals(dataApi.getMmtfProducer(), null);
+		assertNotEquals(dataApi.getMmtfVersion(), null);
+		checkIfSeqResInfoSame(biojavaStruct, params);
+		checkIfEntityInfoSame(biojavaStruct);
+		// Check other features in the data
+	}
 
 
-  /**
-   * Test of sequence and seqres group level information. At the moment the decoder does not parse this data.
-   * This test checks to see if the underlying data is how one would expect.
-   * @param biojavaStruct
-   * @param params
-   */
-  public void checkIfSeqResInfoSame(Structure biojavaStruct, FileParsingParameters params){
-    if(params.isUseInternalChainId()){
-      // Get the seqres group list
-      int[] decodedSeqResGroupList = dataApi.getSeqResGroupIndices();
-      // Get the string sequences
-      Entity[] entityList = dataApi.getEntityList();
-      int groupCounter = 0;
-      int chainCounter = 0;
-      // Get the sequence information - only for the first model
-      for(Chain currentChain : biojavaStruct.getChains()){
-        // Get the entity
-    	Entity currentEntity = null;
-    	for (Entity entity : entityList) {
-    		for (int chainInd : entity.getChainIndexList()) {
-    			if (chainInd==chainCounter) {
-        		currentEntity = entity;
-        		break;
-    			}
-    		}
-    	}
-        assertEquals(currentEntity.getSequence(), currentChain.getSeqResSequence());
-        List<Group> thisChainSeqResList = new ArrayList<>();
-        for(Group seqResGroup : currentChain.getSeqResGroups()){
-          thisChainSeqResList.add(seqResGroup);
-        }
-        // Now go through and check the indices line up
-        for(int i = 0; i < currentChain.getAtomGroups().size(); i++){
-          // Get the group
-          Group testGroup = currentChain.getAtomGroup(i);
-          int testGroupInd = thisChainSeqResList.indexOf(testGroup);
-          assertEquals(testGroupInd, decodedSeqResGroupList[groupCounter]);
-          groupCounter++;
-        }
-        chainCounter++;
-      }
-    }
-    // Otherwise we need to parse in a different
-    else{
-      System.out.println("Using public facing chain ids -> seq res not tested");
-    }
+	/**
+	 * Test to see if the roundtripped entity data is the same as is found in the MMCIF
+	 */
+	public void checkIfEntityInfoSame(Structure biojavaStruct) {    
 
-  }
+		// Fist check it's not null
+		assertNotEquals(dataApi.getNumEntities(), null);
+		// Second check it's the same length
+		assertEquals(dataApi.getNumEntities(), biojavaStruct.getEntityInfos().size());
+		List<Chain> totChains = new ArrayList<>();
+		for (int i=0; i < biojavaStruct.nrModels(); i++) {
+			totChains.addAll(biojavaStruct.getChains(i));
+		}
+		// Now check it has the same information as BioJava
+		for(int i=0; i<dataApi.getNumEntities(); i++) {
+			EntityInfo biojavaEntity = biojavaStruct.getEntityInfos().get(i);
+			assertEquals(dataApi.getEntityDescription(i), biojavaEntity.getDescription());
+			assertEquals(dataApi.getEntityType(i), biojavaEntity.getType().toString());
+			// Now check it maps onto the correct chains
+			List<Chain> bioJavaChains = biojavaEntity.getChains();
+			int[] mmtfList = dataApi.getEntityChainIndexList(i);
+			assertEquals(mmtfList.length, bioJavaChains.size());
+			int[] testList = new int[bioJavaChains.size()];
+			for(int j=0; j<bioJavaChains.size();j++) {
+				testList[j] = totChains.indexOf(bioJavaChains.get(j));
+			}
+			assertArrayEquals(testList, mmtfList);
+
+		}
+	}
+
+
+	/**
+	 * Test of sequence and seqres group level information. At the moment the decoder does not parse this data.
+	 * This test checks to see if the underlying data is how one would expect.
+	 * @param biojavaStruct
+	 * @param params
+	 */
+	public void checkIfSeqResInfoSame(Structure biojavaStruct, FileParsingParameters params){
+		if(params.isUseInternalChainId()){
+			// Get the seqres group list
+			int[] decodedSeqResGroupList = dataApi.getSeqResGroupIndices();
+			// Get the string sequences
+			int groupCounter = 0;
+			int chainCounter = 0;
+			// Get the sequence information - only for the first model
+			String sequence = null;
+			for(Chain currentChain : biojavaStruct.getChains()){
+				for (int i=0; i<dataApi.getNumEntities(); i++) {
+					for (int chainInd : dataApi.getEntityChainIndexList(i)) {
+						if (chainInd==chainCounter) {
+							sequence = dataApi.getEntitySequence(i);
+							break;
+						}
+					}
+				}
+				assertEquals(sequence, currentChain.getSeqResSequence());
+				List<Group> thisChainSeqResList = new ArrayList<>();
+				for(Group seqResGroup : currentChain.getSeqResGroups()){
+					thisChainSeqResList.add(seqResGroup);
+				}
+				// Now go through and check the indices line up
+				for(int i = 0; i < currentChain.getAtomGroups().size(); i++){
+					// Get the group
+					Group testGroup = currentChain.getAtomGroup(i);
+					int testGroupInd = thisChainSeqResList.indexOf(testGroup);
+					assertEquals(testGroupInd, decodedSeqResGroupList[groupCounter]);
+					groupCounter++;
+				}
+				chainCounter++;
+			}
+		}
+		// Otherwise we need to parse in a different
+		else{
+			System.out.println("Using public facing chain ids -> seq res not tested");
+		}
+
+	}
 }

--- a/mmtf-update/src/main/java/org/rcsb/mmtf/testutils/CheckOnRawApi.java
+++ b/mmtf-update/src/main/java/org/rcsb/mmtf/testutils/CheckOnRawApi.java
@@ -51,9 +51,7 @@ public class CheckOnRawApi {
 		// Second check it's the same length
 		assertEquals(dataApi.getNumEntities(), biojavaStruct.getEntityInfos().size());
 		List<Chain> totChains = new ArrayList<>();
-		for (int i=0; i < biojavaStruct.nrModels(); i++) {
-			totChains.addAll(biojavaStruct.getChains(i));
-		}
+		totChains.addAll(biojavaStruct.getChains());
 		// Now check it has the same information as BioJava
 		for(int i=0; i<dataApi.getNumEntities(); i++) {
 			EntityInfo biojavaEntity = biojavaStruct.getEntityInfos().get(i);

--- a/mmtf-update/src/main/java/org/rcsb/mmtf/update/IntegrationTestUtils.java
+++ b/mmtf-update/src/main/java/org/rcsb/mmtf/update/IntegrationTestUtils.java
@@ -8,10 +8,20 @@ import java.util.UUID;
 public class IntegrationTestUtils {
 
 	public static final String[] TEST_CASES = new String[] {
-			//Standard structure
+
+			// THESE CURRENTLY FAIL...
+//			// Weird NMR structure
+//			"1o2f",
+//			// NMR structure with multiple models - one of which has chain missing
+//			"1msh",
+//			// A weird case with incorrect residue numbers.
+//			"3th3",
+//			// Calpha atom is missing (not marked as calpha)
+//			"1lpv",
+			// Standard structure
 			"4cup",
-			// Weird NMR structure
-			"1o2f",
+			// Stanadard NMR structure
+			"2n2z",
 			// Another weird structure (jose's suggestion) 
 			"3zyb",
 			// B-DNA structure
@@ -24,18 +34,13 @@ public class IntegrationTestUtils {
 			"4v5a",
 			// Biosynthetic protein
 			"5emg",
-			// Calpha atom is missing (not marked as calpha)
-			"1lpv",
-			// NMR structure with multiple models - one of which has chain missing
-			"1msh",
+
 			// No ATOM records just HETATM records (in PDB). Opposite true for MMCif. It's a D-Peptide.
 			"1r9v",
 			// Micro heterogenity
 			"4ck4",
 			// Negative residue numbers
 			"5esw",
-			// A weird case with incorrect residue numbers.
-	//		"3th3"
 			};
 
 	public Path returnTempDir() {


### PR DESCRIPTION
- All information that is used once per model is stored once per model
  Coordinate,occupancy and bfactor informatioon are still stored for every atom in every structure.

Fails at least three cases (inhomogeneous NMR models).
//          "1o2f",
//          // NMR structure with multiple models - one of which has chain missing
//          "1msh",
//          // Calpha atom is missing (not marked as calpha)
//          "1lpv",
