### PR TITLE
Removing ParseException

### DIFF
--- a/mmtf-codec/src/main/java/org/rcsb/mmtf/decoder/ReaderUtils.java
+++ b/mmtf-codec/src/main/java/org/rcsb/mmtf/decoder/ReaderUtils.java
@@ -7,7 +7,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.text.ParseException;
 import java.util.zip.GZIPInputStream;
 
 import org.rcsb.mmtf.dataholders.MmtfStructure;
@@ -33,11 +32,10 @@ public class ReaderUtils {
 	 *
 	 * @param pdbCode the pdb code for the desired structure.
 	 * @return the MMTFBean of the deserialized data
-	 * @throws java.text.ParseException if MessagePack cannot be parsed
 	 * @throws IOException if the data cannot be read from the URL
 	 */
 	public static MmtfStructure getDataFromUrl(String pdbCode)
-		throws ParseException, IOException {
+		throws IOException {
 		// Get these as an inputstream
 		byte[] bytes = getByteArrayFromUrl(pdbCode);
 		// Now return the gzip deflated and deserialized byte array
@@ -99,10 +97,9 @@ public class ReaderUtils {
 	 * @param filePath the full path of the file to be read
 	 * @return the deserialized {@link MmtfStructure}
 	 * @throws IOException an error reading the file
-	 * @throws java.text.ParseException if MessagePack cannot be parsed
 	 */
 	public static MmtfStructure getDataFromFile(Path filePath)
-		throws IOException, ParseException {
+		throws IOException {
 		// Now return the gzip deflated and deserialized byte array
 		try (InputStream is = new ByteArrayInputStream(readFile(filePath))) {
 			return getDataFromInputStream(is);
@@ -126,11 +123,10 @@ public class ReaderUtils {
 	 *
 	 * @param inStream the {@link InputStream} to read.
 	 * @return the {@link MmtfStructure} to be returned
-	 * @throws java.text.ParseException if MessagePack cannot be parsed
 	 * @throws java.io.IOException if the inStream cannot be read
 	 */
 	public static MmtfStructure getDataFromInputStream(InputStream inStream)
-		throws ParseException, IOException {
+		throws IOException {
 		MessagePackSerialization mmtfBeanSeDeMessagePackImpl
 			= new MessagePackSerialization();
 		return mmtfBeanSeDeMessagePackImpl.deserialize(inStream);

--- a/mmtf-serialization/src/main/java/org/rcsb/mmtf/serialization/MessagePackSerialization.java
+++ b/mmtf-serialization/src/main/java/org/rcsb/mmtf/serialization/MessagePackSerialization.java
@@ -10,7 +10,6 @@ import org.rcsb.mmtf.dataholders.MmtfStructure;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.DataInputStream;
-import java.text.ParseException;
 import java.util.Map;
 import org.rcsb.mmtf.dataholders.MmtfStructureFactory;
 import org.rcsb.mmtf.serialization.quickmessagepackdeserialization.MessagePackReader;
@@ -43,7 +42,7 @@ public class MessagePackSerialization implements MmtfStructureSerializationInter
 
 	@Override
 	public MmtfStructure deserialize(InputStream inputStream)
-		throws ParseException, IOException {
+		throws IOException {
 		if (useJackson) {
 			return deserializeByJackson(inputStream);
 		} else {
@@ -62,7 +61,7 @@ public class MessagePackSerialization implements MmtfStructureSerializationInter
 	 * Several times faster.
 	 */
 	private MmtfStructure deserializeQuick(InputStream inputStream)
-		throws ParseException, IOException {
+		throws IOException {
 		MessagePackReader mpr = new MessagePackReader(new DataInputStream(inputStream), true);
 		Map<String, Object> map = mpr.readMap();
 		MmtfStructureFactory f = new MmtfStructureFactory();

--- a/mmtf-serialization/src/main/java/org/rcsb/mmtf/serialization/quickmessagepackdeserialization/MessagePackReader.java
+++ b/mmtf-serialization/src/main/java/org/rcsb/mmtf/serialization/quickmessagepackdeserialization/MessagePackReader.java
@@ -2,7 +2,6 @@ package org.rcsb.mmtf.serialization.quickmessagepackdeserialization;
 
 import java.io.DataInputStream;
 import java.io.IOException;
-import java.text.ParseException;
 import java.util.Hashtable;
 import java.util.Map;
 
@@ -79,12 +78,12 @@ public class MessagePackReader {
 		this.stream = dis;
 	}
 
-	public Map<String, Object> readMap() throws ParseException, IOException {
+	public Map<String, Object> readMap() throws IOException {
 		return (Map<String, Object>) getNext(null, 0);
 	}
 
 	private Object getNext(Object array, int pt)
-		throws ParseException, IOException {
+		throws IOException {
 		int b = readByte() & 0xFF;
 		int be0 = b & 0xE0;
 		if ((b & POSITIVEFIXINT_x80) == 0) {
@@ -235,7 +234,7 @@ public class MessagePackReader {
 		return null;
 	}
 
-	private Object getArray(int n) throws ParseException, IOException {
+	private Object getArray(int n) throws IOException {
 		if (isHomo) {
 			if (n == 0) {
 				return null;
@@ -277,7 +276,7 @@ public class MessagePackReader {
 		return o;
 	}
 
-	private Object getMap(int n) throws ParseException, IOException {
+	private Object getMap(int n) throws IOException {
 		Map<String, Object> map = new Hashtable<String, Object>();
 		for (int i = 0; i < n; i++) {
 			String key = getNext(null, 0).toString();
@@ -382,7 +381,7 @@ public class MessagePackReader {
 		return bytesToInt(t8, 0, false);
 	}
 
-	private float readFloat() throws ParseException, IOException {
+	private float readFloat() throws IOException {
 		return intToFloat(readInt());
 	}
 
@@ -414,7 +413,7 @@ public class MessagePackReader {
 			| (bytes[j++] & 0xff) << 16 | (bytes[j++] & 0xff) << 24);
 	}
 
-	private static float intToFloat(int x) throws ParseException {
+	private static float intToFloat(int x) {
 		/**
 		 * see http://en.wikipedia.org/wiki/Binary32
 		 *


### PR DESCRIPTION
It turns out that it was thrown for no reason. Removed it.

The files had CRLFs  and my modifications appear to have touched every line, please use `?w=1` to ignore spaces.