### PR TITLE
Made AdapterToStructureData serializable.

### DIFF
--- a/mmtf-codec/src/main/java/org/rcsb/mmtf/encoder/AdapterToStructureData.java
+++ b/mmtf-codec/src/main/java/org/rcsb/mmtf/encoder/AdapterToStructureData.java
@@ -1,5 +1,6 @@
 package org.rcsb.mmtf.encoder;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -19,8 +20,8 @@ import org.rcsb.mmtf.utils.CodecUtils;
  * @author Anthony Bradley
  *
  */
-public class AdapterToStructureData implements StructureDataInterface, StructureAdapterInterface {
-
+public class AdapterToStructureData implements StructureDataInterface, StructureAdapterInterface, Serializable {
+	private static final long serialVersionUID = 4984676010601174880L;
 
 	/** The X coordinates */
 	private float[] cartnX;


### PR DESCRIPTION
AdapterToStructureData must be serializable for use in Spark. This solves issue #39 .