### PR TITLE
Bugfix: the null strings shouldn't be converted to ""

### DIFF
--- a/mmtf-serialization/src/main/java/org/rcsb/mmtf/serialization/quickmessagepackdeserialization/ObjectTree.java
+++ b/mmtf-serialization/src/main/java/org/rcsb/mmtf/serialization/quickmessagepackdeserialization/ObjectTree.java
@@ -31,7 +31,7 @@ public class ObjectTree {
 	public String getString(String s) {
 		Object o = root.get(s);
 		if (o == null) {
-			return "";
+			return null;
 		} else {
 			return (String) root.get(s);
 		}


### PR DESCRIPTION
Problem introduced with the new quick deserialized that behaves slightly different than the message pack deserializer. The null strings have to be respected or otherwise roundtrips fail to reproduce the same result.