### PR TITLE
ReducedEncoder: handle DOD as solvent

### DIFF
--- a/mmtf-codec/src/main/java/org/rcsb/mmtf/encoder/ReducedEncoder.java
+++ b/mmtf-codec/src/main/java/org/rcsb/mmtf/encoder/ReducedEncoder.java
@@ -237,8 +237,9 @@ public class ReducedEncoder  implements Serializable {
 					atomIndices.add(i);
 				}
 			}
-		} else if (! structure.getGroupName(groupIndex).equals("HOH")
-				|| structure.getGroupName(groupIndex).equals("DOD")) {
+			
+		} else if (! (structure.getGroupName(groupIndex).equals("HOH")
+				|| structure.getGroupName(groupIndex).equals("DOD"))) {
 			// Keep all non-polymer atoms, except for water.
 			// Water should be of type "water", however, a few structures (1ZY8, 2G10, 2Q44, 2Q40)
 			// contain waters as non-polymers. These structures have in common that water has


### PR DESCRIPTION
There was a logic error in the statement that checks for solvents (HOH, DOD): missing parenthesis.