### PR TITLE
8x speed-up by buffering of InputStream during reading of uncompressed files

### DIFF
--- a/mmtf-codec/src/main/java/org/rcsb/mmtf/decoder/ReaderUtils.java
+++ b/mmtf-codec/src/main/java/org/rcsb/mmtf/decoder/ReaderUtils.java
@@ -1,5 +1,6 @@
 package org.rcsb.mmtf.decoder;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -158,6 +159,11 @@ public class ReaderUtils {
 	 */
 	public static MmtfStructure getDataFromInputStream(InputStream inStream)
 		throws IOException {
+		// ensure that InputStream is buffered if needed  (i.e. not externally buffered e.g. via GZIPInputStream)
+		if (!(inStream instanceof BufferedInputStream)) {
+			inStream = new BufferedInputStream(inStream, 65536);
+		}
+
 		MessagePackSerialization mmtfBeanSeDeMessagePackImpl
 			= new MessagePackSerialization();
 		return mmtfBeanSeDeMessagePackImpl.deserialize(inStream);


### PR DESCRIPTION
I ran some benchmarks for the BinaryCIF project/format and in comparison the Java implementation of the MMTF codec was surprisingly slow. Especially when uncompressed (non-gzipped) files were processed. Find benchmark details in the RCSB internal `ciftools-performance` repo.

By employing a `BufferedInputStream` with 65536 buffer size the performance can be improved drastically, resulting in a traversal of the currently 154k structures in 70 s (10 minutes with the current code).

For comparison, read times for BinaryCIF and mmCIF parsing are given (which should be slower due to higher overhead). A performance increase for gzipped files can be expected by using a `GZIPInputStream` with an equally sized buffer of 65536 (in contrast to the default buffer of 512 bytes).

![performance plot](https://raw.githubusercontent.com/rcsb/ciftools-performance/master/R/mmtf-bug/time.png?token=ACKLBZZLVY5DWG52WZNRY6K5JCSDW)